### PR TITLE
chore: fix clone URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This boilerplate is a good starter for a Laravel application using **Vue**, **In
 Clone the repository:
 
 ```console
-$ git clone https://github.com/hawezo:laravel-boilerplate
+$ git clone https://github.com/hawezo/laravel-boilerplate.git
 $ cd laravel-boilerplate
 ```
 


### PR DESCRIPTION
Gonna take this for a spin, the clone url in the readme atm is incorrect.
```
$ git clone https://github.com/hawezo:laravel-boilerplate
Cloning into 'laravel-boilerplate'...
remote: Not Found
fatal: repository 'https://github.com/hawezo:laravel-boilerplate/' not found
```

This corrects it to the right URL