### PR TITLE
Fix PurgeCSS not working properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "axios": "^0.19",
         "cross-env": "^7.0",
         "laravel-mix": "^5.0.1",
-        "laravel-mix-purgecss": "^5.0.0-rc.1",
         "lodash": "^4.17.13",
         "postcss": "^7.0.27",
         "postcss-font-magician": "^2.3.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,6 +8,21 @@
  |
  */
 
+const purgecss = require('@fullhuman/postcss-purgecss')({
+  content: [
+    './src/**/*.php', // `/app` by default, but this setup uses `/src`
+    './resources/**/*.html',
+    './resources/**/*.js',
+    './resources/**/*.jsx',
+    './resources/**/*.ts',
+    './resources/**/*.tsx',
+    './resources/**/*.php',
+    './resources/**/*.vue',
+  ],
+  defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+  whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/],
+});
+
 module.exports = {
   plugins: [
     require('postcss-import'),
@@ -15,5 +30,6 @@ module.exports = {
     require('postcss-nested'),
     require('postcss-font-magician'),
     require('autoprefixer'),
+    ...(process.env.NODE_ENV === 'production' ? [purgecss] : []),
   ],
 };

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,6 +1,5 @@
 const mix = require('laravel-mix');
 const path = require('path');
-require('laravel-mix-purgecss');
 require('laravel-vue-lang/mix');
 
 /*
@@ -26,7 +25,7 @@ mix
 
   // Adds webpack rules
   .webpackConfig({
-    // Code splitting options
+    // Versioning options
     output: { chunkFilename: 'js/[name].js?id=[chunkhash]' },
 
     // Adds aliases for cleaner import
@@ -37,7 +36,7 @@ mix
       },
     },
 
-    // Translator loader
+    // Loader
     module: {
       rules: [
         {
@@ -51,22 +50,6 @@ mix
   // Adds babel plugins
   .babelConfig({
     plugins: ['@babel/plugin-syntax-dynamic-import'],
-  })
-
-  // Registers PurgeCSS
-  .purgeCss({
-    content: [
-      './src/**/*.php', // `/app` by default, but this boilerplate uses `/src`
-      './resources/**/*.html',
-      './resources/**/*.js',
-      './resources/**/*.jsx',
-      './resources/**/*.ts',
-      './resources/**/*.tsx',
-      './resources/**/*.php',
-      './resources/**/*.vue',
-    ],
-    defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-    whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/],
   })
 
   // Enables localization

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,7 +732,7 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-2.6.1.tgz#0e78cc836a1fd997a9a22fa1c26c555411882160"
   integrity sha512-xKN3lAA+xbNhP+JX3sLhzA65IGiKqun/Yf9jBlZX7Og0SxlCrrqKxqTd6ccn20fv3Cgcvq6KnjPhnmS+v7uAwQ==
 
-"@fullhuman/postcss-purgecss@^2.0.5", "@fullhuman/postcss-purgecss@^2.1.0":
+"@fullhuman/postcss-purgecss@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.0.tgz#955fc2e3f69b0d0c84367eeee4f85c01238a65dc"
   integrity sha512-zmV+cK8pAo/suKMQk1fKzDdols5ltOy86Hk51qwkiJJt4olm3t1MaUrm4U4MlA9fiYeRpLqsNop2xNoEm8DV+w==
@@ -4106,13 +4106,6 @@ laravel-localization-loader@^1.0.5:
   dependencies:
     json-loader "^0.5.4"
     php-array-loader "^1.0.0"
-
-laravel-mix-purgecss@^5.0.0-rc.1:
-  version "5.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/laravel-mix-purgecss/-/laravel-mix-purgecss-5.0.0-rc.1.tgz#e83fd2556353c9fd59a42274c8791d1216eab3fc"
-  integrity sha512-N80/4Jn/yHyKK/P1CbzGXC3tYQ9b7I/nYZw45rW2z0QXkXxnPWAWDMaIW1+Da74cz/cPWneRoDYg8ZSj4pvUcg==
-  dependencies:
-    "@fullhuman/postcss-purgecss" "^2.0.5"
 
 laravel-mix@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
`laravel-mix-purgecss` was used, but apparently a bug with `Mix.options` used in conjunction with the `Mix.postCss` method was denying it from functioning (so it's a Laravel Mix issue, not a `laravel-mix-purgecss` issue). 

While waiting for a fix, I moved PurgeCSS' configuration into `postcss.config.js`.